### PR TITLE
Fix broken reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DropSkills App
 
 ## 🎯 Status Projet
-- **Projet IA Veille Premium** mis en **STANDBY** (voir `PROJET_IA_VEILLE_STANDBY.md`)
+- **Projet IA Veille Premium** mis en **STANDBY**
 - Raison : Trop avancé pour l'équipe actuelle
 - Pages supprimées : `/ai-veille`, `/veille/[jobId]`, `/demo-results`
 - Focus actuel : Projets plus simples


### PR DESCRIPTION
## Summary
- remove outdated reference to `PROJET_IA_VEILLE_STANDBY.md` in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684402a6fb80832bbb9ce6b8269e956a