### PR TITLE
Refactor styles to use theme variables

### DIFF
--- a/src/app/compte/page.tsx
+++ b/src/app/compte/page.tsx
@@ -34,8 +34,8 @@ export default function ComptePage() {
 
   if (status === 'loading') {
     return (
-      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#ff0033]"></div>
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     );
   }
@@ -813,19 +813,19 @@ function PreferencesTab() {
             onClick={() => setTheme('light')}
             className={`group relative p-4 rounded-xl border-2 transition-all duration-200 ${
               theme === 'light'
-                ? 'border-[#ff0033] bg-white/10 shadow-lg shadow-[#ff0033]/20'
-                : 'border-[#333] bg-[#1a1a1a] hover:border-[#444] hover:bg-[#222]'
+                ? 'border-primary bg-white/10 shadow-lg shadow-primary/20'
+                : 'border-border bg-card hover:border-border hover:bg-background'
             }`}
             aria-label="Activer le thème clair"
           >
             <div className="flex items-center gap-3 mb-2">
               <div className={`p-2 rounded-lg ${
-                theme === 'light' ? 'bg-[#ff0033] text-white' : 'bg-[#333] text-gray-300'
+                theme === 'light' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
               }`}>
                 <Sun className="w-5 h-5" />
               </div>
               <span className={`font-semibold ${
-                theme === 'light' ? 'text-white' : 'text-gray-200'
+                theme === 'light' ? 'text-foreground' : 'text-muted-foreground'
               }`}>
                 Mode Clair
               </span>
@@ -853,19 +853,19 @@ function PreferencesTab() {
             onClick={() => setTheme('dark')}
             className={`group relative p-4 rounded-xl border-2 transition-all duration-200 ${
               theme === 'dark'
-                ? 'border-[#ff0033] bg-white/10 shadow-lg shadow-[#ff0033]/20'
-                : 'border-[#333] bg-[#1a1a1a] hover:border-[#444] hover:bg-[#222]'
+                ? 'border-primary bg-white/10 shadow-lg shadow-primary/20'
+                : 'border-border bg-card hover:border-border hover:bg-background'
             }`}
             aria-label="Activer le thème sombre"
           >
             <div className="flex items-center gap-3 mb-2">
               <div className={`p-2 rounded-lg ${
-                theme === 'dark' ? 'bg-[#ff0033] text-white' : 'bg-[#333] text-gray-300'
+                theme === 'dark' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
               }`}>
                 <Moon className="w-5 h-5" />
               </div>
               <span className={`font-semibold ${
-                theme === 'dark' ? 'text-white' : 'text-gray-200'
+                theme === 'dark' ? 'text-foreground' : 'text-muted-foreground'
               }`}>
                 Mode Sombre
               </span>
@@ -876,7 +876,7 @@ function PreferencesTab() {
               )}
             </div>
             <p className={`text-sm text-left ${
-              theme === 'dark' ? 'text-gray-300' : 'text-gray-400'
+              theme === 'dark' ? 'text-muted-foreground' : 'text-muted-foreground'
             }`}>
               Interface sombre et élégante, confortable pour les yeux en soirée
             </p>
@@ -915,7 +915,7 @@ function PreferencesTab() {
         <select
           value={preferences.language}
           onChange={(e) => setPreferences({...preferences, language: e.target.value})}
-          className="w-full bg-[#1a1a1a] border border-[#333] rounded-lg px-4 py-3 text-white focus:outline-none focus:border-[#ff0033]"
+          className="w-full bg-card border border-border rounded-lg px-4 py-3 text-card-foreground focus:outline-none focus:border-primary"
         >
           <option value="fr">Français</option>
           <option value="en">English</option>
@@ -930,7 +930,7 @@ function PreferencesTab() {
         <select
           value={preferences.timezone}
           onChange={(e) => setPreferences({...preferences, timezone: e.target.value})}
-          className="w-full bg-[#1a1a1a] border border-[#333] rounded-lg px-4 py-3 text-white focus:outline-none focus:border-[#ff0033]"
+          className="w-full bg-card border border-border rounded-lg px-4 py-3 text-card-foreground focus:outline-none focus:border-primary"
         >
           <option value="Europe/Paris">Paris (UTC+1)</option>
           <option value="Europe/London">Londres (UTC+0)</option>
@@ -940,7 +940,7 @@ function PreferencesTab() {
 
       <button
         onClick={handleSave}
-        className="flex items-center gap-2 bg-[#ff0033] text-white px-6 py-3 rounded-lg font-semibold hover:bg-[#cc0029] transition-colors"
+        className="flex items-center gap-2 bg-primary text-primary-foreground px-6 py-3 rounded-lg font-semibold hover:bg-primary transition-colors"
       >
         <Save className="w-4 h-4" />
         Sauvegarder

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -293,3 +293,36 @@ a {
 .border-border {
   border-color: var(--border);
 }
+
+/* New utility classes for theme variables */
+.bg-background {
+  background-color: var(--background);
+}
+
+.bg-foreground {
+  background-color: var(--foreground);
+}
+
+.bg-primary {
+  background-color: var(--primary);
+}
+
+.text-primary {
+  color: var(--primary);
+}
+
+.text-primary-foreground {
+  color: var(--primary-foreground);
+}
+
+.bg-muted {
+  background-color: var(--muted);
+}
+
+.border-primary {
+  border-color: var(--primary);
+}
+
+.text-card-foreground {
+  color: var(--card-foreground);
+}

--- a/src/app/home_trae/page.tsx
+++ b/src/app/home_trae/page.tsx
@@ -105,10 +105,10 @@ export default function HomeTraePage() {
             en Business Rentable
           </h1>
           
-          <p className="text-xl md:text-2xl text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Accédez à un catalogue premium de formations, templates et outils. 
+          <p className="text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed">
+            Accédez à un catalogue premium de formations, templates et outils.
             <br className="hidden md:block" />
-            Revendez avec <strong className="text-[#ff0033]">95% de marge</strong> et une livraison automatisée.
+            Revendez avec <strong className="text-primary">95% de marge</strong> et une livraison automatisée.
           </p>
         </motion.div>
 
@@ -133,7 +133,7 @@ export default function HomeTraePage() {
           <motion.button
             whileHover={{ scale: 1.05 }}
             onClick={() => setIsPlaying(!isPlaying)}
-            className="flex items-center gap-2 px-6 py-4 border border-gray-600 hover:border-gray-400 rounded-xl transition-all duration-300"
+            className="flex items-center gap-2 px-6 py-4 border border-border hover:border-border rounded-xl transition-all duration-300"
           >
             <Play className="w-5 h-5" />
             Voir la démo (2 min)
@@ -151,13 +151,13 @@ export default function HomeTraePage() {
             <motion.div
               key={index}
               whileHover={{ scale: 1.05 }}
-              className="bg-[#1a1a1a]/50 backdrop-blur-sm border border-gray-800 rounded-xl p-4 text-center"
+              className="bg-card/50 backdrop-blur-sm border border-border rounded-xl p-4 text-center"
             >
-              <div className="flex justify-center mb-2 text-[#ff0033]">
+              <div className="flex justify-center mb-2 text-primary">
                 {stat.icon}
               </div>
               <div className="text-2xl font-bold">{stat.value}</div>
-              <div className="text-sm text-gray-400">{stat.label}</div>
+              <div className="text-sm text-muted-foreground">{stat.label}</div>
             </motion.div>
           ))}
         </motion.div>
@@ -176,9 +176,9 @@ export default function HomeTraePage() {
           className="text-center mb-16"
         >
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
-            Explorez notre <span className="text-[#ff0033]">Catalogue Premium</span>
+            Explorez notre <span className="text-primary">Catalogue Premium</span>
           </h2>
-          <p className="text-xl text-gray-300 max-w-2xl mx-auto">
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
             Découvrez en temps réel le contenu de nos produits les plus vendus
           </p>
         </motion.div>
@@ -193,22 +193,22 @@ export default function HomeTraePage() {
                 whileHover={{ scale: 1.02 }}
                 onClick={() => setActiveDemo(index)}
                 className={`p-6 rounded-xl border cursor-pointer transition-all duration-300 ${
-                  activeDemo === index 
-                    ? 'bg-[#ff0033]/10 border-[#ff0033] shadow-lg shadow-[#ff0033]/20' 
-                    : 'bg-[#1a1a1a]/50 border-gray-800 hover:border-gray-600'
+                  activeDemo === index
+                    ? 'bg-primary/10 border-primary shadow-lg shadow-primary/20'
+                    : 'bg-card/50 border-border hover:border-border'
                 }`}
               >
                 <div className="flex items-start justify-between mb-3">
                   <div>
                     <h3 className="font-bold text-lg">{demo.title}</h3>
-                    <p className="text-gray-400 text-sm">{demo.description}</p>
+                    <p className="text-muted-foreground text-sm">{demo.description}</p>
                   </div>
                   <div className="text-right">
                     <div className="text-[#ff0033] font-bold">{demo.price}</div>
-                    <div className="text-xs text-gray-500">{demo.category}</div>
+                    <div className="text-xs text-muted-foreground">{demo.category}</div>
                   </div>
                 </div>
-                <div className="flex items-center gap-2 text-sm text-gray-400">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Eye className="w-4 h-4" />
                   <span>Aperçu disponible</span>
                   {activeDemo === index && (
@@ -231,15 +231,15 @@ export default function HomeTraePage() {
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.5 }}
-            className="bg-[#1a1a1a] border border-gray-800 rounded-xl p-6 h-96 overflow-hidden relative"
+            className="bg-card border border-border rounded-xl p-6 h-96 overflow-hidden relative"
           >
-            <div className="flex items-center gap-2 mb-4 pb-4 border-b border-gray-800">
+            <div className="flex items-center gap-2 mb-4 pb-4 border-b border-border">
               <div className="flex gap-2">
                 <div className="w-3 h-3 bg-red-500 rounded-full" />
                 <div className="w-3 h-3 bg-yellow-500 rounded-full" />
                 <div className="w-3 h-3 bg-green-500 rounded-full" />
               </div>
-              <div className="text-sm text-gray-400 ml-4">
+              <div className="text-sm text-muted-foreground ml-4">
                 {demos[activeDemo].title} - Aperçu
               </div>
             </div>
@@ -251,10 +251,10 @@ export default function HomeTraePage() {
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ duration: 0.3, delay: index * 0.1 }}
-                  className="flex items-center gap-3 p-3 bg-[#0a0a0a] rounded-lg"
+                  className="flex items-center gap-3 p-3 bg-background rounded-lg"
                 >
                   <CheckCircle className="w-4 h-4 text-green-400 flex-shrink-0" />
-                  <span className="text-gray-300">{line}</span>
+                  <span className="text-muted-foreground">{line}</span>
                 </motion.div>
               ))}
             </div>
@@ -265,7 +265,7 @@ export default function HomeTraePage() {
               transition={{ delay: 0.5 }}
               className="absolute bottom-4 right-4"
             >
-              <div className="flex items-center gap-2 text-sm text-gray-400">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Download className="w-4 h-4" />
                 <span>Téléchargement instantané</span>
               </div>
@@ -334,13 +334,13 @@ export default function HomeTraePage() {
               transition={{ duration: 0.5, delay: index * 0.1 }}
               whileHover={{ scale: 1.05, y: -5 }}
               viewport={{ once: true }}
-              className="group relative bg-[#1a1a1a]/50 backdrop-blur-sm border border-gray-800 rounded-xl p-6 hover:border-gray-600 transition-all duration-300"
+              className="group relative bg-card/50 backdrop-blur-sm border border-border rounded-xl p-6 hover:border-border transition-all duration-300"
             >
               <div className={`inline-flex p-3 rounded-lg bg-gradient-to-r ${feature.color} mb-4`}>
                 {feature.icon}
               </div>
               <h3 className="font-bold text-xl mb-3">{feature.title}</h3>
-              <p className="text-gray-400 leading-relaxed">{feature.description}</p>
+              <p className="text-muted-foreground leading-relaxed">{feature.description}</p>
               
               <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-xl" />
             </motion.div>
@@ -360,7 +360,7 @@ export default function HomeTraePage() {
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
             Prêt à lancer votre <span className="text-[#ff0033]">Empire Digital</span> ?
           </h2>
-          <p className="text-xl text-gray-300 mb-8">
+          <p className="text-xl text-muted-foreground mb-8">
             Rejoignez les 300+ entrepreneurs qui génèrent des revenus passifs avec DropSkills
           </p>
           
@@ -378,14 +378,14 @@ export default function HomeTraePage() {
             
             <motion.button
               whileHover={{ scale: 1.05 }}
-              className="px-8 py-4 border border-gray-600 hover:border-gray-400 rounded-xl transition-all duration-300 flex items-center gap-2"
+              className="px-8 py-4 border border-border hover:border-border rounded-xl transition-all duration-300 flex items-center gap-2"
             >
               <Mail className="w-5 h-5" />
               Parler à un expert
             </motion.button>
           </div>
           
-          <div className="mt-8 flex justify-center items-center gap-6 text-sm text-gray-400">
+          <div className="mt-8 flex justify-center items-center gap-6 text-sm text-muted-foreground">
             <div className="flex items-center gap-2">
               <CheckCircle className="w-4 h-4 text-green-400" />
               <span>Sans engagement</span>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -70,7 +70,7 @@ function ProductGridSimplified() {
       <div>
         <div className="flex flex-col sm:flex-row gap-4 mb-6 items-center">
           <select
-            className="bg-[#18181b] text-white rounded-lg px-4 py-2 border border-[#232323] focus:outline-none"
+            className="bg-card text-card-foreground rounded-lg px-4 py-2 border border-border focus:outline-none"
             value={category}
             onChange={e => setCategory(e.target.value)}
           >
@@ -80,7 +80,7 @@ function ProductGridSimplified() {
             ))}
           </select>
           <select
-            className="bg-[#18181b] text-white rounded-lg px-4 py-2 border border-[#232323] focus:outline-none"
+            className="bg-card text-card-foreground rounded-lg px-4 py-2 border border-border focus:outline-none"
             value={format}
             onChange={e => setFormat(e.target.value)}
           >
@@ -92,7 +92,7 @@ function ProductGridSimplified() {
           <input
             type="text"
             placeholder="Rechercher un produit..."
-            className="flex-1 bg-[#18181b] text-white rounded-lg px-4 py-2 border border-[#232323] focus:outline-none"
+            className="flex-1 bg-card text-card-foreground rounded-lg px-4 py-2 border border-border focus:outline-none"
             value={search}
             onChange={e => setSearch(e.target.value)}
           />
@@ -102,7 +102,7 @@ function ProductGridSimplified() {
             <ProductCard key={product.id} product={product} />
           ))}
           {filtered.length === 0 && (
-            <div className="col-span-full text-center text-gray-400 py-12">Aucun produit trouvé.</div>
+            <div className="col-span-full text-center text-muted-foreground py-12">Aucun produit trouvé.</div>
           )}
         </div>
       </div>

--- a/src/components/LayoutWithSidebar.tsx
+++ b/src/components/LayoutWithSidebar.tsx
@@ -68,7 +68,7 @@ export default function LayoutWithSidebar({
         {/* Header mobile */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <Link href="/" className="text-2xl font-extrabold">
-            DROP <span className="text-[#ff0033]">SKILLS</span>
+            DROP <span className="text-primary">SKILLS</span>
           </Link>
           <button
             onClick={() => setMobileMenuOpen(false)}
@@ -91,7 +91,7 @@ export default function LayoutWithSidebar({
           
           {/* Divider */}
           <div className="my-4 border-t border-border"></div>
-          <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
             Outils IA Dropskills
           </div>
           
@@ -124,7 +124,7 @@ export default function LayoutWithSidebar({
 
           {/* Aide & Support */}
           <div className="my-4 border-t border-border"></div>
-          <div className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
             Aide & Support
           </div>
           
@@ -149,9 +149,9 @@ export default function LayoutWithSidebar({
           </button>
           
           {user && (
-            <div className="mt-3 text-center text-xs text-gray-400">
+            <div className="mt-3 text-center text-xs text-muted-foreground">
               Connecté en tant que {user.email}
-              <div className="text-[#ff0033] font-medium mt-1">
+              <div className="text-primary font-medium mt-1">
                 {/* Premium à implémenter selon vos besoins */}
                 {user.email === 'cyril.iriebi@gmail.com' && '🔧 Admin'}
               </div>
@@ -169,7 +169,7 @@ export default function LayoutWithSidebar({
         {/* Header mobile avec bouton menu */}
         <div className="lg:hidden bg-card border-b border-border p-4 flex items-center justify-between">
           <h1 className="text-xl font-bold text-foreground">
-            DROP<span className="text-[#ff0033]">SKILLS</span>
+            DROP<span className="text-primary">SKILLS</span>
           </h1>
           <button
             onClick={() => setMobileMenuOpen(true)}
@@ -185,8 +185,8 @@ export default function LayoutWithSidebar({
         <div className="p-4 lg:p-6">
           {isLoading ? (
             <div className="flex items-center justify-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#ff0033]"></div>
-              <span className="ml-2 text-gray-300">Chargement...</span>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              <span className="ml-2 text-muted-foreground">Chargement...</span>
             </div>
           ) : (
             children
@@ -219,12 +219,12 @@ function MobileNavLink({ icon, label, href, badge, isPremium, onClick }: MobileN
       </div>
       <span className="font-medium">{label}</span>
       {badge && badge > 0 && (
-        <span className="ml-auto bg-[#ff0033] text-white text-xs px-2 py-1 rounded-full">
+        <span className="ml-auto bg-primary text-primary-foreground text-xs px-2 py-1 rounded-full">
           {badge}
         </span>
       )}
       {isPremium && (
-        <Lock className="ml-auto w-4 h-4 text-gray-400" />
+        <Lock className="ml-auto w-4 h-4 text-muted-foreground" />
       )}
     </Link>
   );


### PR DESCRIPTION
## Summary
- add utility classes for theme vars in `globals.css`
- switch sidebar layout and homepage forms to use variables
- adapt home page and other pages to theme classes
- tweak account page theme selector and loading state

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440ef38188832b8b7ec897565329d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all user interface elements to use consistent, theme-based color classes instead of hardcoded color values. This affects backgrounds, text, borders, buttons, spinners, dropdowns, and badges across account, home, and layout pages.
- **New Features**
  - Added new CSS utility classes for theme colors, enabling easier and more flexible theming throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->