### PR TITLE
Fix Tonalite ConseilBlock usage

### DIFF
--- a/src/components/usp-steps/TonaliteStep.tsx
+++ b/src/components/usp-steps/TonaliteStep.tsx
@@ -61,10 +61,12 @@ export function TonaliteStep({ data, onChange, errors }: TonaliteStepProps) {
         </TooltipField>
       </div>
 
-      <ConseilBlock
-        title="Conseil Dropskills AI"
-        content="La tonalité doit être cohérente avec votre audience cible et votre positionnement. Une tonalité professionnelle convient aux services B2B, tandis qu'une approche plus décontractée peut mieux fonctionner pour le B2C."
-      />
+      <ConseilBlock title="Conseil Dropskills AI">
+        La tonalité doit être cohérente avec votre audience cible et votre
+        positionnement. Une tonalité professionnelle convient aux services B2B,
+        tandis qu'une approche plus décontractée peut mieux fonctionner pour le
+        B2C.
+      </ConseilBlock>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use children instead of deprecated `content` prop in `TonaliteStep`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e528954832b808093f0084713d6