### PR TITLE
Fix sponsorship admin actions

### DIFF
--- a/src/app/admin/sponsorship/page.tsx
+++ b/src/app/admin/sponsorship/page.tsx
@@ -253,16 +253,28 @@ export default function SponsorshipPage() {
     }
   ];
 
-  const actions = [
+  interface ActionData {
+    label: string;
+    onClick: () => void;
+    variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+    icon?: React.ReactNode;
+    loading?: boolean;
+  }
+
+  const actions: ActionData[] = [
     {
       label: "Exporter données",
-      href: "#export",
-      variant: "primary" as const
+      variant: "default",
+      onClick: () => {
+        window.location.href = "#export";
+      }
     },
     {
       label: "Envoyer rappels",
-      href: "#remind",
-      variant: "secondary" as const
+      variant: "secondary",
+      onClick: () => {
+        window.location.href = "#remind";
+      }
     }
   ];
 
@@ -272,15 +284,7 @@ export default function SponsorshipPage() {
       title="Gestion du parrainage"
       subtitle="Administration du programme de parrainage"
       stats={statsData}
-      actions={actions.map(action => ({
-        ...action,
-        href: action.href,
-        variant: action.variant === 'primary' ? 'default' : action.variant,
-        ...action,
-        variant: action.variant as "default" | "destructive" | "outline" | "secondary" | "ghost" | "link",
-        ...action,
-        onClick: () => window.location.href = action.href
-      }))}
+      actions={actions}
     >
       <SponsorshipManagement />
     </AdminLayoutWithSidebar>


### PR DESCRIPTION
## Summary
- define `actions` typed as `ActionData[]`
- simplify passing actions to `AdminLayoutWithSidebar`
- add redirect actions for export and remind buttons

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e4a9878832b9970519f9039e374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the structure and clarity of action buttons on the sponsorship admin page, ensuring more consistent behavior and appearance. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->