### PR TITLE
Update session types with admin flag

### DIFF
--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { AI_PROVIDERS, TOOL_PROVIDER_MAPPING } from '@/lib/ai-providers';
-import { supabaseAdmin } from '@/lib/supabase';
 import fs from 'fs';
 import path from 'path';
 
@@ -11,10 +10,10 @@ export const dynamic = 'force-dynamic';
 // GET: Récupérer la configuration actuelle
 
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.isAdmin) {
+    if (!session?.user.isAdmin) {
       return NextResponse.json({ error: 'Accès non autorisé' }, { status: 403 });
     }
     return NextResponse.json({
@@ -48,7 +47,7 @@ export async function GET(request: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const session = await getServerSession(authOptions);
-    if (!session?.user?.isAdmin) {
+    if (!session?.user.isAdmin) {
       return NextResponse.json({ error: 'Accès non autorisé' }, { status: 403 });
     }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -8,6 +8,7 @@ declare module 'next-auth' {
       name?: string | null;
       firstName?: string | null;
       lastName?: string | null;
+      isAdmin?: boolean;
     };
   }
 
@@ -17,6 +18,7 @@ declare module 'next-auth' {
     name?: string | null;
     firstName?: string | null;
     lastName?: string | null;
+    isAdmin?: boolean;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend `Session` and `User` types with optional `isAdmin` flag
- tidy admin API route and check new flag

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461e4c1784832b818180fff8bd52cf