### PR TITLE
Fix DeepSeek provider mapping

### DIFF
--- a/src/app/admin/ai-config/page.tsx
+++ b/src/app/admin/ai-config/page.tsx
@@ -174,13 +174,13 @@ export default function AIConfigPage() {
 
   const getOptimalMapping = () => {
     const toolsConfig = {
-      'titles': { name: 'Titres', defaultProvider: 'deepseek' },
-      'descriptions': { name: 'Descriptions', defaultProvider: 'deepseek' },
-      'emails': { name: 'Emails', defaultProvider: 'deepseek' },
-      'veille': { name: 'Veille', defaultProvider: 'deepseek' },
+      'titles': { name: 'Titres', defaultProvider: 'deepseek-v3' },
+      'descriptions': { name: 'Descriptions', defaultProvider: 'deepseek-v3' },
+      'emails': { name: 'Emails', defaultProvider: 'deepseek-v3' },
+      'veille': { name: 'Veille', defaultProvider: 'deepseek-v3' },
       'content': { name: 'Contenu', defaultProvider: 'openai' },
-      'usp': { name: 'USP', defaultProvider: 'deepseek' },
-      'icp': { name: 'ICP', defaultProvider: 'deepseek' }
+      'usp': { name: 'USP', defaultProvider: 'deepseek-v3' },
+      'icp': { name: 'ICP', defaultProvider: 'deepseek-v3' }
     };
     
     return Object.entries(toolsConfig).map(([toolId, config]) => {

--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -93,13 +93,13 @@ export async function PUT() {
   try {
     // Configuration par défaut optimisée
     const defaultMapping = {
-      'titles': 'deepseek',
-      'descriptions': 'deepseek', 
-      'emails': 'deepseek',
-      'veille': 'deepseek',
+      'titles': 'deepseek-v3',
+      'descriptions': 'deepseek-v3',
+      'emails': 'deepseek-v3',
+      'veille': 'deepseek-v3',
       'content': 'openai', // Garde OpenAI pour le contenu long
-      'usp': 'deepseek',
-      'icp': 'deepseek'
+      'usp': 'deepseek-v3',
+      'icp': 'deepseek-v3'
     };
     
     // Mise à jour du mapping

--- a/src/lib/ai-providers.ts
+++ b/src/lib/ai-providers.ts
@@ -165,13 +165,13 @@ export const AI_PROVIDERS: Record<string, AIProvider> = {
 
 // Configuration par défaut du mapping des outils vers les providers
 const DEFAULT_TOOL_PROVIDER_MAPPING: Record<string, string> = {
-  'titles': 'deepseek',
-  'descriptions': 'deepseek', 
-  'emails': 'deepseek',
-  'veille': 'deepseek',
+  'titles': 'deepseek-v3',
+  'descriptions': 'deepseek-v3',
+  'emails': 'deepseek-v3',
+  'veille': 'deepseek-v3',
   'content': 'openai', // Garde OpenAI pour le contenu long
-  'usp': 'deepseek',
-  'icp': 'deepseek'
+  'usp': 'deepseek-v3',
+  'icp': 'deepseek-v3'
 };
 
 // Fonction pour charger la configuration depuis le fichier ou utiliser les valeurs par défaut


### PR DESCRIPTION
## Summary
- align default provider mapping with existing `deepseek-v3` provider

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840019b16ec832b8404a00aa3c03cc5